### PR TITLE
add syslogging and add the config option to set a server host header

### DIFF
--- a/constants/constants.go
+++ b/constants/constants.go
@@ -10,6 +10,7 @@ var (
 	BindHost           = os.Getenv("BIND_HOST")
 	BindPort           = os.Getenv("BIND_PORT")
 	InternalHost       = os.Getenv("INTERNAL_ADDRESS")
+	ServerHost         = os.Getenv("SERVER_HOST")
 	CertPath           = os.Getenv("CERT_PATH")
 	KeyPath            = os.Getenv("KEY_PATH")
 	Ssl                bool

--- a/handlers/admin.go
+++ b/handlers/admin.go
@@ -2,7 +2,7 @@ package handlers
 
 import (
 	"github.com/gin-gonic/gin"
-	"github.com/pritunl/pritunl-web/request"
+	"github.com/issuu/pritunl-web/request"
 )
 
 func adminGet(c *gin.Context) {

--- a/handlers/auth.go
+++ b/handlers/auth.go
@@ -2,7 +2,7 @@ package handlers
 
 import (
 	"github.com/gin-gonic/gin"
-	"github.com/pritunl/pritunl-web/request"
+	"github.com/issuu/pritunl-web/request"
 )
 
 type authSessionPostData struct {

--- a/handlers/event.go
+++ b/handlers/event.go
@@ -2,7 +2,7 @@ package handlers
 
 import (
 	"github.com/gin-gonic/gin"
-	"github.com/pritunl/pritunl-web/request"
+	"github.com/issuu/pritunl-web/request"
 )
 
 func eventGet(c *gin.Context) {

--- a/handlers/handlers.go
+++ b/handlers/handlers.go
@@ -2,7 +2,7 @@ package handlers
 
 import (
 	"fmt"
-	"github.com/Sirupsen/logrus"
+	log "github.com/sirupsen/logrus"
 	"github.com/dropbox/godropbox/errors"
 	"github.com/gin-gonic/gin"
 	"net/http"
@@ -11,7 +11,7 @@ import (
 func Recovery(c *gin.Context) {
 	defer func() {
 		if r := recover(); r != nil {
-			logrus.WithFields(logrus.Fields{
+			log.WithFields(log.Fields{
 				"error": errors.New(fmt.Sprintf("%s", r)),
 			}).Error("handlers: Handler panic")
 			c.Writer.WriteHeader(http.StatusInternalServerError)
@@ -24,7 +24,7 @@ func Recovery(c *gin.Context) {
 func Errors(c *gin.Context) {
 	c.Next()
 	for _, err := range c.Errors {
-		logrus.WithFields(logrus.Fields{
+		log.WithFields(log.Fields{
 			"error": err,
 		}).Error("handlers: Handler error")
 	}

--- a/handlers/host.go
+++ b/handlers/host.go
@@ -2,7 +2,7 @@ package handlers
 
 import (
 	"github.com/gin-gonic/gin"
-	"github.com/pritunl/pritunl-web/request"
+	"github.com/issuu/pritunl-web/request"
 )
 
 func hostGet(c *gin.Context) {

--- a/handlers/key.go
+++ b/handlers/key.go
@@ -2,7 +2,7 @@ package handlers
 
 import (
 	"github.com/gin-gonic/gin"
-	"github.com/pritunl/pritunl-web/request"
+	"github.com/issuu/pritunl-web/request"
 )
 
 func keyGet(c *gin.Context) {

--- a/handlers/link.go
+++ b/handlers/link.go
@@ -2,7 +2,7 @@ package handlers
 
 import (
 	"github.com/gin-gonic/gin"
-	"github.com/pritunl/pritunl-web/request"
+	"github.com/issuu/pritunl-web/request"
 )
 
 func linkGet(c *gin.Context) {

--- a/handlers/log.go
+++ b/handlers/log.go
@@ -2,7 +2,7 @@ package handlers
 
 import (
 	"github.com/gin-gonic/gin"
-	"github.com/pritunl/pritunl-web/request"
+	"github.com/issuu/pritunl-web/request"
 )
 
 func logGet(c *gin.Context) {

--- a/handlers/org.go
+++ b/handlers/org.go
@@ -2,7 +2,7 @@ package handlers
 
 import (
 	"github.com/gin-gonic/gin"
-	"github.com/pritunl/pritunl-web/request"
+	"github.com/issuu/pritunl-web/request"
 )
 
 func orgGet(c *gin.Context) {

--- a/handlers/ping.go
+++ b/handlers/ping.go
@@ -2,7 +2,7 @@ package handlers
 
 import (
 	"github.com/gin-gonic/gin"
-	"github.com/pritunl/pritunl-web/request"
+	"github.com/issuu/pritunl-web/request"
 )
 
 func pingGet(c *gin.Context) {

--- a/handlers/server.go
+++ b/handlers/server.go
@@ -2,7 +2,7 @@ package handlers
 
 import (
 	"github.com/gin-gonic/gin"
-	"github.com/pritunl/pritunl-web/request"
+	"github.com/issuu/pritunl-web/request"
 )
 
 func serverGet(c *gin.Context) {

--- a/handlers/settings.go
+++ b/handlers/settings.go
@@ -2,7 +2,7 @@ package handlers
 
 import (
 	"github.com/gin-gonic/gin"
-	"github.com/pritunl/pritunl-web/request"
+	"github.com/issuu/pritunl-web/request"
 )
 
 func settingsGet(c *gin.Context) {

--- a/handlers/setup.go
+++ b/handlers/setup.go
@@ -2,7 +2,7 @@ package handlers
 
 import (
 	"github.com/gin-gonic/gin"
-	"github.com/pritunl/pritunl-web/request"
+	"github.com/issuu/pritunl-web/request"
 )
 
 func setupGet(c *gin.Context) {

--- a/handlers/static.go
+++ b/handlers/static.go
@@ -2,7 +2,7 @@ package handlers
 
 import (
 	"github.com/gin-gonic/gin"
-	"github.com/pritunl/pritunl-web/request"
+	"github.com/issuu/pritunl-web/request"
 	"path"
 	"strings"
 )

--- a/handlers/status.go
+++ b/handlers/status.go
@@ -2,7 +2,7 @@ package handlers
 
 import (
 	"github.com/gin-gonic/gin"
-	"github.com/pritunl/pritunl-web/request"
+	"github.com/issuu/pritunl-web/request"
 )
 
 func statusGet(c *gin.Context) {

--- a/handlers/subscription.go
+++ b/handlers/subscription.go
@@ -2,7 +2,7 @@ package handlers
 
 import (
 	"github.com/gin-gonic/gin"
-	"github.com/pritunl/pritunl-web/request"
+	"github.com/issuu/pritunl-web/request"
 )
 
 func subscriptionGet(c *gin.Context) {

--- a/handlers/user.go
+++ b/handlers/user.go
@@ -2,7 +2,7 @@ package handlers
 
 import (
 	"github.com/gin-gonic/gin"
-	"github.com/pritunl/pritunl-web/request"
+	"github.com/issuu/pritunl-web/request"
 )
 
 func usersGet(c *gin.Context) {

--- a/request/request.go
+++ b/request/request.go
@@ -1,12 +1,15 @@
 package request
 
 import (
+        //"fmt"
+        //log "github.com/sirupsen/logrus"
+
 	"bytes"
 	"encoding/json"
 	"github.com/dropbox/godropbox/errors"
 	"github.com/gin-gonic/gin"
-	"github.com/pritunl/pritunl-web/constants"
-	"github.com/pritunl/pritunl-web/errortypes"
+	"github.com/issuu/pritunl-web/constants"
+	"github.com/issuu/pritunl-web/errortypes"
 	"io"
 	"net/http"
 	"net/url"
@@ -69,9 +72,13 @@ func (r *Request) Do(c *gin.Context) {
 		return
 	}
 
+	forwardHost := c.Request.Host
+	if constants.ServerHost != "" {
+		forwardHost = constants.ServerHost
+	}
 	forwardUrl := url.URL{
 		Scheme: constants.Scheme,
-		Host:   c.Request.Host,
+		Host:   forwardHost,
 	}
 
 	if r.Query != nil {


### PR DESCRIPTION
I'm not sure if what I'm doing is the correct way of handling/fixing this ?

But we notices that on our site pritunl.example.com you could 

```
curl --header "Host: bing.com" pritunl.example.com
<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 3.2 Final//EN">
<title>Redirecting...</title>
<h1>Redirecting...</h1>
<p>You should be redirected automatically to target URL: <a href="https://bing.com/login">https://bing.com/login</a>.  If not click the link.

```